### PR TITLE
Bump up versions to match current Carbone

### DIFF
--- a/images/doc-gen-api/app/package-lock.json
+++ b/images/doc-gen-api/app/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "@bcgov/carbone-copy-api": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bcgov/carbone-copy-api/-/carbone-copy-api-2.0.0.tgz",
-      "integrity": "sha512-S6/W5G0L+MvRfQvMMiWtnCDThcsZZCG7+DHLqfryM3IErxAjOcvh/wZVBbCdimCYoqx/3KCpV3BwIA3G7YBrpQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bcgov/carbone-copy-api/-/carbone-copy-api-2.1.1.tgz",
+      "integrity": "sha512-va12nuPuXxd3OyqP1gCtJPU58manVSHTQwkaH+roLz3so9NMq0tf1+EHZW/VXvlAf9t68MkWXhSnrqt/+WLlMg==",
       "requires": {
-        "@bcgov/carbone-render": "^2.0.0",
+        "@bcgov/carbone-render": "~2.1.1",
         "@bcgov/file-cache": "^1.0.3",
         "api-problem": "^6.1.4",
         "bytes": "^3.1.0",
@@ -39,9 +39,9 @@
       }
     },
     "@bcgov/carbone-render": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bcgov/carbone-render/-/carbone-render-2.0.0.tgz",
-      "integrity": "sha512-rpQ/qSute+cHF7BYvg3xxPOObkqI0J2KSxg9pfkAwDW3F6yKKFEfjSMBCn2GWd9jd5t6rcuFRpM7RBzO//EkUA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bcgov/carbone-render/-/carbone-render-2.1.1.tgz",
+      "integrity": "sha512-V6D+Y7y1crAiYstCHyTYFt5vQ/j/91dNhgwOWlm6qbwFBR7nsv7lhIgcSSJcAuNKY1cToG84HrtchvxicV2H2g==",
       "requires": {
         "carbone": "^2.1.1",
         "fs-extra": "^9.0.1",
@@ -1741,9 +1741,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "validator": {
       "version": "13.1.17",

--- a/images/doc-gen-api/app/package.json
+++ b/images/doc-gen-api/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-gen-api",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "description": "Document Generation API",
   "main": "app.js",
   "scripts": {
@@ -25,7 +25,7 @@
     }
   ],
   "dependencies": {
-    "@bcgov/carbone-copy-api": "^2.0.0",
+    "@bcgov/carbone-copy-api": "~2.1.1",
     "api-problem": "^6.1.4",
     "body-parser": "^1.19.0",
     "express": "^4.17.1"

--- a/npm/carbone-copy-api/package-lock.json
+++ b/npm/carbone-copy-api/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bcgov/carbone-copy-api",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bcgov/carbone-render": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bcgov/carbone-render/-/carbone-render-2.0.0.tgz",
-      "integrity": "sha512-rpQ/qSute+cHF7BYvg3xxPOObkqI0J2KSxg9pfkAwDW3F6yKKFEfjSMBCn2GWd9jd5t6rcuFRpM7RBzO//EkUA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bcgov/carbone-render/-/carbone-render-2.1.1.tgz",
+      "integrity": "sha512-V6D+Y7y1crAiYstCHyTYFt5vQ/j/91dNhgwOWlm6qbwFBR7nsv7lhIgcSSJcAuNKY1cToG84HrtchvxicV2H2g==",
       "requires": {
         "carbone": "^2.1.1",
         "fs-extra": "^9.0.1",

--- a/npm/carbone-copy-api/package.json
+++ b/npm/carbone-copy-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/carbone-copy-api",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "description": "Express API for calling Carbone with a file caching layer.",
   "main": "index.js",
   "directories": {
@@ -36,7 +36,7 @@
     "carbone-render"
   ],
   "dependencies": {
-    "@bcgov/carbone-render": "^2.0.0",
+    "@bcgov/carbone-render": "~2.1.1",
     "@bcgov/file-cache": "^1.0.3",
     "api-problem": "^6.1.4",
     "bytes": "^3.1.0",

--- a/npm/carbone-render/package-lock.json
+++ b/npm/carbone-render/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/carbone-render",
-  "version": "1.0.3",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/carbone-render/package.json
+++ b/npm/carbone-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/carbone-render",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "description": "Async wrapper around Carbone render",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Bump up versions to match current Carbone.
Need to ensure that no on grabs the multiversion lib simply by using npm semantics.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
