### PR TITLE
Don't throw an unhandled exception if the user doesn't supply an "opt…

### DIFF
--- a/npm/carbone-copy-api/validation.js
+++ b/npm/carbone-copy-api/validation.js
@@ -170,7 +170,7 @@ const modelValidation = {
     }
     if (!models.carbone.options(obj.options)) {
       errors.push({value: obj.options, message: 'Invalid value `options`.'});
-    } else {
+    } else if(obj.options) {
       if (!models.carbone.convertTo(obj.options.convertTo)) {
         errors.push({value: obj.options.convertTo, message: 'Invalid value `options.convertTo`.'});
       }


### PR DESCRIPTION
If you don't supply an "options" object in the posted json, an unhandled exception is thrown and your request is held open until it times out. 

I was posting to the "/template/render" endpoint but it looks like the validation is common to all endpoints.

```
TypeError: Cannot read property 'convertTo' of undefined
    at Object.carbone (/opt/app-root/src/app/node_modules/@bcgov/carbone-copy-api/validation.js:174:49)
    at Object.template (/opt/app-root/src/app/node_modules/@bcgov/carbone-copy-api/validation.js:199:40)
    at validateTemplate (/opt/app-root/src/app/node_modules/@bcgov/carbone-copy-api/validation.js:276:42)
    at Layer.handle [as handle_request] (/opt/app-root/src/app/node_modules/express/lib/router/layer.js:95:5)
    at next (/opt/app-root/src/app/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/opt/app-root/src/app/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/opt/app-root/src/app/node_modules/express/lib/router/layer.js:95:5)
    at /opt/app-root/src/app/node_modules/express/lib/router/index.js:281:22
    at Function.process_params (/opt/app-root/src/app/node_modules/express/lib/router/index.js:335:12)
    at next (/opt/app-root/src/app/node_modules/express/lib/router/index.js:275:10)
```