### PR TITLE
Deprecate doc-gen-api, carbone-copy-api, carbone-render and file-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,17 @@ The following is a list of the packages currently in this repository:
 
 - [bcgovimages/alpine-node-libreoffice](images/alpine-node-libreoffice)
   - [![version](https://img.shields.io/docker/v/bcgovimages/alpine-node-libreoffice.svg?sort=semver)](https://hub.docker.com/r/bcgovimages/alpine-node-libreoffice) [![pulls](https://img.shields.io/docker/pulls/bcgovimages/alpine-node-libreoffice.svg)](https://hub.docker.com/r/bcgovimages/alpine-node-libreoffice) [![size](https://img.shields.io/docker/image-size/bcgovimages/alpine-node-libreoffice.svg)](https://hub.docker.com/r/bcgovimages/alpine-node-libreoffice)
-- [bcgovimages/doc-gen-api](images/doc-gen-api)
+- [Deprecated] [bcgovimages/doc-gen-api](images/doc-gen-api)
   - [![version](https://img.shields.io/docker/v/bcgovimages/doc-gen-api.svg?sort=semver)](https://hub.docker.com/r/bcgovimages/doc-gen-api) [![pulls](https://img.shields.io/docker/pulls/bcgovimages/doc-gen-api.svg)](https://hub.docker.com/r/bcgovimages/doc-gen-api) [![size](https://img.shields.io/docker/image-size/bcgovimages/doc-gen-api.svg)](https://hub.docker.com/r/bcgovimages/doc-gen-api)
+  - `doc-gen-api` has been succeeded by [common-document-generation-service](https://hub.docker.com/r/bcgovimages/common-document-generation-service)
 
 ### NPM Packages
 
-- [@bcgov/carbone-copy-api](npm/carbone-copy-api)
+- [Deprecated] [@bcgov/carbone-copy-api](npm/carbone-copy-api)
   - [![npm](https://img.shields.io/npm/v/@bcgov/carbone-copy-api.svg)](https://www.npmjs.com/package/@bcgov/carbone-copy-api) [![downloads](https://img.shields.io/npm/dm/@bcgov/carbone-copy-api.svg)](https://npmcharts.com/compare/@bcgov/carbone-copy-api?minimal=true)
-- [@bcgov/carbone-render](npm/carbone-render)
+- [Deprecated] [@bcgov/carbone-render](npm/carbone-render)
   - [![npm](https://img.shields.io/npm/v/@bcgov/carbone-render.svg)](https://www.npmjs.com/package/@bcgov/carbone-render) [![downloads](https://img.shields.io/npm/dm/@bcgov/carbone-render.svg)](https://npmcharts.com/compare/@bcgov/carbone-render?minimal=true)
-- [@bcgov/file-cache](npm/file-cache)
+- [Deprecated] [@bcgov/file-cache](npm/file-cache)
   - [![npm](https://img.shields.io/npm/v/@bcgov/file-cache.svg)](https://www.npmjs.com/package/@bcgov/file-cache) [![downloads](https://img.shields.io/npm/dm/@bcgov/file-cache.svg)](https://npmcharts.com/compare/@bcgov/file-cache?minimal=true)
 
 ## Directory Structure

--- a/images/doc-gen-api/README.md
+++ b/images/doc-gen-api/README.md
@@ -1,4 +1,6 @@
-# Document Generation API
+# [Deprecated] Document Generation API
+
+*Note: This image will no longer be receiving support updates as it has been succeeded by [common-document-generation-service](https://github.com/bcgov/common-document-generation-service). Please migrate to common-document-generation-service to continue receiving support updates.*
 
 [![version](https://img.shields.io/docker/v/bcgovimages/doc-gen-api.svg?sort=semver)](https://hub.docker.com/r/bcgovimages/doc-gen-api)
 [![pulls](https://img.shields.io/docker/pulls/bcgovimages/doc-gen-api.svg)](https://hub.docker.com/r/bcgovimages/doc-gen-api)

--- a/npm/carbone-copy-api/README.md
+++ b/npm/carbone-copy-api/README.md
@@ -1,4 +1,6 @@
-# carbone-copy-api
+# [Deprecated] carbone-copy-api
+
+*Note: This package has been deprecated and will no longer be receiving support updates.*
 
 [![npm](https://img.shields.io/npm/v/@bcgov/carbone-copy-api.svg)](https://www.npmjs.com/package/@bcgov/carbone-copy-api)
 [![downloads](https://img.shields.io/npm/dm/@bcgov/carbone-copy-api.svg)](https://npmcharts.com/compare/@bcgov/carbone-copy-api?minimal=true)

--- a/npm/carbone-copy-api/package-lock.json
+++ b/npm/carbone-copy-api/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bcgov/carbone-copy-api",
-  "version": "2.2.1",
-  "lockfileVersion": 1,
+  "version": "2.2.2",
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/carbone-copy-api",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bcgov/carbone-render": "^2.2.1",
-        "@bcgov/file-cache": "^1.0.5",
+        "@bcgov/carbone-render": "^2.2.2",
+        "@bcgov/file-cache": "^1.0.6",
         "api-problem": "^7.0.2",
         "bytes": "^3.1.0",
         "express": "^4.17.1",
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@bcgov/carbone-render": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bcgov/carbone-render/-/carbone-render-2.2.1.tgz",
-      "integrity": "sha512-xfrkbfdsLqLO64lJ4FzFy+qXvZQThqCHf8MBfBnZTbtH5n6V/ehacr5L8ZiY9voYBj35ZvRItqa2RWk5PKM91w==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bcgov/carbone-render/-/carbone-render-2.2.2.tgz",
+      "integrity": "sha512-8xNAkRduGy5bJNGNO9yD1mqpjtnHIRyLQarjQ+bZPL7Z8kA0NB4GzRnLE/y3WF6aRZnwpnsCYTXcdvK2qt62UA==",
       "dependencies": {
         "carbone": "^3.1.0",
         "fs-extra": "^10.0.0",
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@bcgov/file-cache": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@bcgov/file-cache/-/file-cache-1.0.5.tgz",
-      "integrity": "sha512-GNCKvmG6ck8E9ZRW18batVU/lLBCjeode0f/X1YaQLAVLYRLit3GwBXuNQrsOPoCO2RIA7CiMlzmQGFWhB7j/g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@bcgov/file-cache/-/file-cache-1.0.6.tgz",
+      "integrity": "sha512-QlWYL9j3R5AZ4kpnim5M40J5y65fihpO+w0E8P5JlqsETjddZ6lw0+blvrYiUJF+467A8anMnnk4CYtNPvCLWg==",
       "dependencies": {
         "fs-extra": "^10.0.0",
         "uuid": "^8.3.2"
@@ -1169,9 +1169,9 @@
   },
   "dependencies": {
     "@bcgov/carbone-render": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bcgov/carbone-render/-/carbone-render-2.2.1.tgz",
-      "integrity": "sha512-xfrkbfdsLqLO64lJ4FzFy+qXvZQThqCHf8MBfBnZTbtH5n6V/ehacr5L8ZiY9voYBj35ZvRItqa2RWk5PKM91w==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bcgov/carbone-render/-/carbone-render-2.2.2.tgz",
+      "integrity": "sha512-8xNAkRduGy5bJNGNO9yD1mqpjtnHIRyLQarjQ+bZPL7Z8kA0NB4GzRnLE/y3WF6aRZnwpnsCYTXcdvK2qt62UA==",
       "requires": {
         "carbone": "^3.1.0",
         "fs-extra": "^10.0.0",
@@ -1179,9 +1179,9 @@
       }
     },
     "@bcgov/file-cache": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@bcgov/file-cache/-/file-cache-1.0.5.tgz",
-      "integrity": "sha512-GNCKvmG6ck8E9ZRW18batVU/lLBCjeode0f/X1YaQLAVLYRLit3GwBXuNQrsOPoCO2RIA7CiMlzmQGFWhB7j/g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@bcgov/file-cache/-/file-cache-1.0.6.tgz",
+      "integrity": "sha512-QlWYL9j3R5AZ4kpnim5M40J5y65fihpO+w0E8P5JlqsETjddZ6lw0+blvrYiUJF+467A8anMnnk4CYtNPvCLWg==",
       "requires": {
         "fs-extra": "^10.0.0",
         "uuid": "^8.3.2"

--- a/npm/carbone-copy-api/package.json
+++ b/npm/carbone-copy-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/carbone-copy-api",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Express API for calling Carbone with a file caching layer.",
   "main": "index.js",
   "directories": {
@@ -40,8 +40,8 @@
     "carbone-render"
   ],
   "dependencies": {
-    "@bcgov/carbone-render": "^2.2.1",
-    "@bcgov/file-cache": "^1.0.5",
+    "@bcgov/carbone-render": "^2.2.2",
+    "@bcgov/file-cache": "^1.0.6",
     "api-problem": "^7.0.2",
     "bytes": "^3.1.0",
     "express": "^4.17.1",

--- a/npm/carbone-render/README.md
+++ b/npm/carbone-render/README.md
@@ -1,4 +1,6 @@
-# carbone-render
+# [Deprecated] carbone-render
+
+*Note: This package has been deprecated and will no longer be receiving support updates.*
 
 [![npm](https://img.shields.io/npm/v/@bcgov/carbone-render.svg)](https://www.npmjs.com/package/@bcgov/carbone-render)
 [![downloads](https://img.shields.io/npm/dm/@bcgov/carbone-render.svg)](https://npmcharts.com/compare/@bcgov/carbone-render?minimal=true)

--- a/npm/carbone-render/package-lock.json
+++ b/npm/carbone-render/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/carbone-render",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/carbone-render/package.json
+++ b/npm/carbone-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/carbone-render",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Async wrapper around Carbone render",
   "main": "index.js",
   "scripts": {

--- a/npm/file-cache/README.md
+++ b/npm/file-cache/README.md
@@ -1,4 +1,6 @@
-# file-cache
+# [Deprecated] file-cache
+
+*Note: This package has been deprecated and will no longer be receiving support updates.*
 
 [![npm](https://img.shields.io/npm/v/@bcgov/file-cache.svg)](https://www.npmjs.com/package/@bcgov/file-cache)
 [![downloads](https://img.shields.io/npm/dm/@bcgov/file-cache.svg)](https://npmcharts.com/compare/@bcgov/file-cache?minimal=true)

--- a/npm/file-cache/package-lock.json
+++ b/npm/file-cache/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/file-cache",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/file-cache/package.json
+++ b/npm/file-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/file-cache",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Simple file storage that generates hashes for stored files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
After the consolidation of CDOGS, we will no longer be supporting doc-gen-api, carbone-copy-api, carbone-render and file-cache. This PR updates the documentation to ensure that they are flagged appropriately.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2076](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2076)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
